### PR TITLE
Add es256k alg for PyJWT

### DIFF
--- a/views/website/libraries/1-Python.json
+++ b/views/website/libraries/1-Python.json
@@ -23,6 +23,7 @@
         "rs384": true,
         "rs512": true,
         "es256": true,
+        "es256k": true,
         "es384": true,
         "es512": true,
         "ps256": true,


### PR DESCRIPTION
from version 2.1.0 pyjwt supports es256k